### PR TITLE
Homebrew Launcher not downloading

### DIFF
--- a/data/setup.json
+++ b/data/setup.json
@@ -52,7 +52,7 @@
         "steps":[
             {
                 "type": "extractFile",
-                "file": "homebrew_launcher.v1.3.zip",
+                "file": "homebrew_launcher.v1.4.zip",
                 "path": ""
             }
         ]


### PR DESCRIPTION
(hopefully) fixed an issue where the zip of the homebrew launcher had a wrong name, wouldn't be extracted correctly and therefore wouldn't be included in the downloaded zip file